### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: ✅ Validate & Monitor
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/dr-fadil-profile/security/code-scanning/1](https://github.com/Fadil369/dr-fadil-profile/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow. The best way is to set it at the top level of the workflow file, so it applies to all jobs unless overridden. Since the jobs in this workflow only check out code, run tests, and summarize results (they do not push, create releases, or modify issues), the minimal required permission is `contents: read`. This should be added immediately after the `name:` field and before the `on:` block in `.github/workflows/deploy.yml`. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
