### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/dr-fadil-profile/index.html
+++ b/dr-fadil-profile/index.html
@@ -6476,6 +6476,17 @@
                 }, 1000 + Math.random() * 1000);
             }
 
+            // Escape HTML special characters in user input
+            escapeHTML(str) {
+                return String(str)
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#39;')
+                    .replace(/\//g, '&#x2F;');
+            }
+
             addMessage(content, type) {
                 const messagesContainer = document.getElementById('chatMessages');
                 const messageHTML = `
@@ -6484,7 +6495,7 @@
                             <i class="fas fa-${type === 'user' ? 'user' : 'stethoscope'}"></i>
                         </div>
                         <div class="message-content">
-                            <p>${content}</p>
+                            <p>${this.escapeHTML(content)}</p>
                         </div>
                     </div>
                 `;


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/dr-fadil-profile/security/code-scanning/5](https://github.com/Fadil369/dr-fadil-profile/security/code-scanning/5)

To fix this vulnerability, escape special HTML characters in the user-provided input before injecting it into the DOM using `insertAdjacentHTML`. The fix should ensure that sequences such as `<`, `>`, `&`, `"`, `'`, and `/` are replaced by their respective HTML entities in all user-provided content that is pasted into an HTML context. 

Specifically, in `addMessage(content, type)`, before interpolating `content` into the `messageHTML` template, we should define and use a helper function that performs this escaping. The best practice is to add a function called `escapeHTML` at an appropriate scope (inside or above the chat class/object, as visible in the code block), and use it like:  
```js
<p>${escapeHTML(content)}</p>
```
in the message HTML template.

The change should be applied inside `dr-fadil-profile/index.html` in the block defining `addMessage`. Minimal changes ensure no other logic is affected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
