### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/dr-fadil-profile/security/code-scanning/28](https://github.com/Fadil369/dr-fadil-profile/security/code-scanning/28)

To fix the problem, add an explicit `permissions` block that grants only the minimal privileges required for the workflow. For an npm publish workflow, generally you only need `contents: read`, unless you are also creating or modifying releases, pull requests, or issues. In this code sample, the workflow runs on a release event and does not appear to require write access to the repository contents or other resources. Therefore, add a top-level `permissions: contents: read` block. This will apply to both jobs unless a job-level override is provided (which is not needed here).

Add the following block immediately after the workflow `name:` at the top of `.github/workflows/npm-publish.yml`:

```yaml
permissions:
  contents: read
```

No imports or special dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
