### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/dr-fadil-profile/security/code-scanning/29](https://github.com/Fadil369/dr-fadil-profile/security/code-scanning/29)

To fix this, add an explicit `permissions` key to the workflow YAML file. In this context, the `build` job only checks out and builds the package, so `contents: read` is the minimum necessary. The `publish-npm` job performs a `npm publish` to the public npm registry, using a personal npm token (not `GITHUB_TOKEN`), so it also just needs `contents: read` rights to the repository source, not any write rights to the repo or packages on GitHub. Therefore, setting `permissions: contents: read` at the top level (for all jobs) is the safest, minimal starting point, as recommended. Add the following block just after (or before) the `on:` block.

**Files/lines to change:**  
- File: `.github/workflows/npm-publish.yml`
- Insert `permissions: contents: read` after `name: Node.js Package` (line 5), before or after the `on:` block (lines 6-9).

No new methods or imports are needed for this YAML-only change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
